### PR TITLE
GitButler Integration Commit

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -10,18 +10,16 @@ jobs:
         python-version: [ "3.10" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Lint with Ruff
-        uses: chartboost/ruff-action@v1
-        continue-on-error: true
       - name: Test with pytest
         run: |
           coverage run -m pytest  -v -s


### PR DESCRIPTION
This is an integration commit for the virtual branches that GitButler is tracking.

Due to GitButler managing multiple virtual branches, you cannot switch back and forth between git branches and virtual branches easily. 

If you switch to another branch, GitButler will need to be reinitialized. If you commit on this branch, GitButler will throw it away.

Here are the branches that are currently applied:
 - Update actions checkout and setup python (refs/gitbutler/Update-actions-checkout-and-setup-python)
   - .github/workflows/run_test.yml
   - dialogue/index_data.py
   - .pre-commit-config.yaml
 - 🚀 feat: update GitHub Actions workflow to use actions/checkout@v4 and actions/setup-python@v5, and add caching for pip (refs/gitbutler/-feat-update-GitHub-Actions-workflow-to-use-actions/checkout-v4-and-actions/setup-python-v5-and-add-caching-for-pip-) branch head: efb8acba448b40a7451f0f48fb0c476ea73ab980

Your previous branch was: refs/heads/main

The sha for that commit was: 5aad9e551966ab828800c8a6c06c1fa8dedfd968

For more information about what we're doing here, check out our docs: https://docs.gitbutler.com/features/virtual-branches/integration-branch